### PR TITLE
Use call_user_func() to trigger callback method

### DIFF
--- a/engine/engineAPI/latest/modules/router/router.php
+++ b/engine/engineAPI/latest/modules/router/router.php
@@ -198,7 +198,7 @@ class router {
 
 		$variables = $this->getVariables();
 
-		return $route['callback']($this->serverURI,$variables);
+		return call_user_func($route['callback'], $this->serverURI,$variables);
 
 	}
 


### PR DESCRIPTION
This allows callbacks to be object methods and not just global functions. 
(Really it allows anything that PHP considers 'callable')
